### PR TITLE
Improve manifest

### DIFF
--- a/me.sanchezrodriguez.passes.json
+++ b/me.sanchezrodriguez.passes.json
@@ -34,13 +34,10 @@
             "buildsystem" : "meson",
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://github.com/pablo-s/passes.git"
+                    "type" : "dir",
+                    "path" : "."
                 }
             ]
         }
-    ],
-    "build-options" : {
-        "env" : {        }
-    }
+    ]
 }


### PR DESCRIPTION
This uses the local directory instead of the repo's URL, as it will be easier for developers to test local changes. This also removes the unnecessary build envs