### PR TITLE
data: metainfo: add missing initial paragraph

### DIFF
--- a/data/me.sanchezrodriguez.passes.metainfo.xml.in
+++ b/data/me.sanchezrodriguez.passes.metainfo.xml.in
@@ -20,6 +20,7 @@
 	<releases>
 			<release date="2023-11-14" version="0.9">
 			<description translate="no">
+				<p>What is new?</p>
 				<ul>
 					<li>Added the ability to sort passes based on different criteria.</li>
 					<li>Visual refinements to match the state of the art of GNOME apps.</li>


### PR DESCRIPTION
Appstream file validation fails with the following error message:

```
data/me.sanchezrodriguez.passes.metainfo.xml: FAILED:
• style-invalid         : <ul> cannot start a description [(null)]
• style-invalid         : Not enough <p> tags for a good description [0/1]
```

Adding a simple paragraph at the beginning of the release description fixes this issue.