### PR TITLE
Use raw-strings where required

### DIFF
--- a/src/formats/pkpass/pkpass_factory.py
+++ b/src/formats/pkpass/pkpass_factory.py
@@ -65,7 +65,7 @@ class PkPassFactory(PassFactory):
                 # For every type of image (background, footer, icon, logo, strip
                 # and thumbnail), only load the image with lowest resolution
 
-                image_type = re.split('\.|@', file_name)[0]
+                image_type = re.split(r'\.|@', file_name)[0]
 
                 if image_type in pass_images.keys():
                     continue

--- a/src/model/digital_pass.py
+++ b/src/model/digital_pass.py
@@ -159,7 +159,7 @@ class Color:
     @classmethod
     def from_css(this_class, css_string):
         if css_string.startswith('rgb'):
-            result = re.search('rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)',
+            result = re.search(r'rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)',
                                css_string)
 
             if not result or len(result.groups()) != 3:
@@ -170,7 +170,7 @@ class Color:
             b = result.group(3)
 
         elif css_string.startswith('#'):
-            result = re.search('\#(\S{2})(\S{2})(\S{2})(\S{2})',
+            result = re.search(r'\#(\S{2})(\S{2})(\S{2})(\S{2})',
                                css_string)
 
             if not result or len(result.groups()) != 4:
@@ -305,7 +305,7 @@ class Date:
         # Include hours and seconds if they have not been specified.
         # Why? DateTime.new_from_iso8601 does not accept times without them.
 
-        matches = re.finditer('(T|t)([0-9]{2}\:?)+(\+|\-|Z)?', string)
+        matches = re.finditer(r'(T|t)([0-9]{2}\:?)+(\+|\-|Z)?', string)
 
         for match in matches:
             missing_info = None

--- a/src/view/pass_viewer/pass_field_row.py
+++ b/src/view/pass_viewer/pass_field_row.py
@@ -41,17 +41,17 @@ class PassFieldRow(Adw.ActionRow):
             value = GLib.markup_escape_text(value)
 
             # Create a link for URLs
-            value = re.sub('(?:(https?://)|(www))(\S+)',
+            value = re.sub(r'(?:(https?://)|(www))(\S+)',
                            '<a href="https://\\2\\3">\\1\\2\\3</a>',
                            value)
 
             # Create a link for telephone numbers
-            value = re.sub('(\+\d+[\(\)\-\d\s\.]+\d)',
+            value = re.sub(r'(\+\d+[\(\)\-\d\s\.]+\d)',
                            '<a href="tel:\\1">\\1</a>',
                            value)
 
             # Create a link for e-mails
-            value = re.sub('(\S+\@[\w\-]+\.\w+)',
+            value = re.sub(r'(\S+\@[\w\-]+\.\w+)',
                            '<a href="mailto:\\1">\\1</a>',
                            value)
 


### PR DESCRIPTION
Addresses SyntaxWarnings introduced with Python 3.12+:

```
SyntaxWarning: invalid escape sequence '\:'
```

Closes #46