### PR TITLE
Fixing oversized primary fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@
 
 You can build *Passes* using GNOME Builder: import the project and press the Play button.
 
+<details>
+  <summary>Dependencies</summary>
+
+  Passes requires flatpak-builder to be installed alongside gnome-builder
+  
+</details>
+
 ## Install
 
 The recommended way of installing *Passes* is via Flatpak:

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ You can build *Passes* using GNOME Builder: import the project and press the Pla
 
 <details>
   <summary>Dependencies</summary>
+  <br>
 
-  Passes requires flatpak-builder to be installed alongside gnome-builder
-  
+  Passes requires `flatpak-builder` to be installed alongside gnome-builder  
 </details>
 
 ## Install

--- a/src/formats/pkpass/pkpass_plotter.py
+++ b/src/formats/pkpass/pkpass_plotter.py
@@ -233,7 +233,18 @@ class BoardingPassPlotter(PkPassPlotter):
                                         value_font = PassFont.biggest_value,
                                         alignment = Pango.Alignment.RIGHT)
 
+        # Check if font size needs to be reduced
+        if origin_field.get_value_width() > (max_row_width / 2) or destination_field.get_value_width() > (max_row_width / 2):
+            origin_field.set_value_font(PassFont.big_value)
+            destination_field.set_value_font(PassFont.big_value)
+
+        if origin_field.get_value_width() > (max_row_width / 2) or destination_field.get_value_width() > (max_row_width / 2):
+            origin_field.set_value_font(PassFont.value)
+            destination_field.set_value_font(PassFont.value)
+
+        # Set final widths
         destination_field.set_width(self.pass_width() - 2 * self.pass_margin())
+        origin_field.set_width(max_row_width / 2)
         self._snapshot.save()
 
         point = Graphene.Point()

--- a/src/formats/pkpass/pkpass_plotter.py
+++ b/src/formats/pkpass/pkpass_plotter.py
@@ -92,14 +92,18 @@ class PkPassPlotter(PassPlotter):
 
     def _plot_header(self):
         header_height = 32
+        header_width = self.pass_width() - (self.pass_margin() * 2)
 
         # Draw the logo if it exists
         if self._logo_texture:
-            logo_scale = header_height / self._logo_texture.get_height()
-            logo_width = self._logo_texture.get_width() * logo_scale
+            logo_height_scale = header_height / self._logo_texture.get_height()
+            logo_width_scale = (header_width / 2) / self._logo_texture.get_width()
+            logo_scale = logo_height_scale if logo_height_scale < logo_width_scale else logo_width_scale
+            scaled_logo_width = self._logo_texture.get_width() * logo_scale
+            scaled_logo_height = self._logo_texture.get_height() * logo_scale
 
             rectangle = Graphene.Rect()
-            rectangle.init(self.pass_margin(), self.pass_margin(), logo_width, header_height)
+            rectangle.init(self.pass_margin(), self.pass_margin(), scaled_logo_width, scaled_logo_height)
             self._snapshot.append_texture(self._logo_texture, rectangle)
 
         point = Graphene.Point()

--- a/src/view/pass_viewer/pass_widget.py
+++ b/src/view/pass_viewer/pass_widget.py
@@ -84,6 +84,12 @@ class FieldLayout:
 
     def get_width(self):
         return self.__label.get_width() / Pango.SCALE
+    
+    def get_value_width(self):
+        return self.__value.get_pixel_size().width
+    
+    def set_value_font(self, font):
+        self.__value.set_font_description(font)
 
     def set_alignment(self, alignment):
         self.__label.set_alignment(alignment)


### PR DESCRIPTION
Wide logos and long primary field values break the layout as seen here:

![Screenshot From 2025-01-06 23-10-08](https://github.com/user-attachments/assets/b314d740-0fd6-404c-a522-9ca658933c62)
![Screenshot From 2025-01-06 23-08-33](https://github.com/user-attachments/assets/9bc4c199-0296-4b08-8444-df350c180643)
![Screenshot From 2025-01-06 23-08-27](https://github.com/user-attachments/assets/bd5c97a5-acc1-4a4d-8543-6dcc171f64ff)

The fix proposed would change the following to:

![Screenshot From 2025-01-06 23-10-28](https://github.com/user-attachments/assets/25fce35b-8508-4801-9438-d359a7e3f952)
![Screenshot From 2025-01-06 23-07-58](https://github.com/user-attachments/assets/da64237a-1a39-41c6-8c6b-93d60e742dd3)
![Screenshot From 2025-01-06 23-08-03](https://github.com/user-attachments/assets/65ea251d-ce60-4565-b1e3-cf88a278a3be)

This Pull request also adds a note about the flatpak-builder dependency