### PR TITLE
Use bitmap_width/bitmap_height instead of width/height

### DIFF
--- a/src/model/barcode_content_encoder.c
+++ b/src/model/barcode_content_encoder.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <zint.h>
 #include <stdlib.h>
+#include <string.h>
 
 const char FOREGROUND = '1';
 const char BACKGROUND = '2';
@@ -23,30 +24,9 @@ char * encode_2d_symbol(struct zint_symbol* symbol, unsigned char * data, unsign
     symbol->output_options |= OUT_BUFFER_INTERMEDIATE;
 
     ZBarcode_Encode_and_Buffer(symbol, data, data_length, 0);
-
-    unsigned amount_of_modules = (symbol->height * symbol->width) + 1;
-    unsigned module_size = symbol->bitmap_width / symbol->width;
-
+    unsigned amount_of_modules = (symbol->bitmap_height * symbol->bitmap_width) + 1;
     char* modules = malloc(amount_of_modules * sizeof(char));
-
-    unsigned bitmap_index = 0;
-    unsigned modules_index = 0;
-    for (int row = 0; row < symbol->height; row++)
-    {
-        for (int column = 0; column < symbol->width; column++)
-        {
-            char module = symbol->bitmap[bitmap_index] == FOREGROUND?
-                FOREGROUND : BACKGROUND;
-
-            modules[modules_index] = module;
-
-            bitmap_index += module_size;
-            modules_index++;
-        }
-
-        bitmap_index += symbol->width * module_size;
-    }
-
+    memcpy(modules, symbol->bitmap, amount_of_modules - 1);
     modules[amount_of_modules - 1] = '\0';
 
     return modules;
@@ -83,8 +63,8 @@ char * encode_barcode(unsigned char * data,
     }
 
     last_result = encode_2d_symbol(symbol, data, data_length);
-    *out_width = symbol->width;
-    *out_height = symbol->height;
+    *out_width = symbol->bitmap_width;
+    *out_height = symbol->bitmap_height;
 
     ZBarcode_Delete(symbol);
 


### PR DESCRIPTION
bitmap_width / width isn't always an integer value. As a result bitmap_index points to wrong elements in bitmap and created barcode representation in modules is broken. Let's use bitmap representation created by libzint.