### PR TITLE
Use appstreamcli for MetaInfo validation

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -22,10 +22,10 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
-    args: ['validate', '--nonet', appstream_file]
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli,
+    args: ['validate', '--no-net', '--explain', appstream_file]
   )
 endif
 


### PR DESCRIPTION
Hi!

The `appstream-util` tool is deprecated and does not support modern MetaInfo files, so this patch replaces it with its more up-to-date alternative (the same validation that FlatHub uses).

Thanks for considering the patch! :-)