### PR TITLE
Add support for EAN barcodes

### DIFF
--- a/src/model/barcode_content_encoder.c
+++ b/src/model/barcode_content_encoder.c
@@ -12,7 +12,8 @@ enum BarcodeType
     AZTEC = 0,
     CODE128,
     PDF417,
-    QRCODE
+    QRCODE,
+    EAN,
 };
 
 char * encode_2d_symbol(struct zint_symbol* symbol, unsigned char * data, unsigned data_length);
@@ -59,6 +60,10 @@ char * encode_barcode(unsigned char * data,
         case QRCODE:
             symbol->symbology = BARCODE_QRCODE;
             symbol->option_1 = 1; // Error Correction Level L=1 M=2 Q=3 H=4
+            break;
+
+        case EAN:
+            symbol->symbology = BARCODE_EANX;
             break;
     }
 

--- a/src/model/barcode_content_encoder.py.in
+++ b/src/model/barcode_content_encoder.py.in
@@ -26,6 +26,7 @@ class BarcodeType(IntEnum):
     CODE128 = 1
     PDF417 = 2
     QRCODE = 3
+    EAN = 4
 
 
 class BarcodeContentEncoder():
@@ -79,4 +80,8 @@ class BarcodeContentEncoder():
     @classmethod
     def encode_qr_code(this_class, text, encoding):
         return this_class.encode_barcode(text, BarcodeType.QRCODE, encoding)
+
+    @classmethod
+    def encode_ean_code(this_class, text, encoding):
+        return this_class.encode_barcode(text, BarcodeType.EAN, encoding)
 

--- a/src/view/barcode_widget.py
+++ b/src/view/barcode_widget.py
@@ -102,6 +102,9 @@ class BarcodeWidget(Gtk.Widget):
         elif format in ['PKBarcodeFormatQR', 'QR_CODE']:
             encoding_function = BarcodeContentEncoder.encode_qr_code
 
+        elif format in ['EAN']:
+            encoding_function = BarcodeContentEncoder.encode_ean_code
+
         else:
             raise BarcodeFormatNotSupported()
 


### PR DESCRIPTION
A lot of loyalty cards in some areas use EAN (European Article Number) bar-codes (EAN-8, EAN-13). The length can be automatically detected based on the length of the message.