### PR TITLE
Fix crash, when primary fields cannot be parsed for BoardingPass

### DIFF
--- a/src/formats/pkpass/pkpass_plotter.py
+++ b/src/formats/pkpass/pkpass_plotter.py
@@ -213,6 +213,9 @@ class BoardingPassPlotter(PkPassPlotter):
 
     def _plot_primary_fields(self):
 
+        if not self._primary_fields:
+            return
+
         max_row_width = self.pass_width() - 2 * self.pass_margin()
 
         # Origin


### PR DESCRIPTION
When we cannot parse primary fields, rather skip them than crash the boarding pass.

Closes: #67