### PR TITLE
Honor PKPass dateStyle and timeStyle when formatting date fields

### DIFF
--- a/src/formats/pkpass/pkpass.py
+++ b/src/formats/pkpass/pkpass.py
@@ -302,8 +302,14 @@ class StandardField(PassField):
 
             value = pkpass_field_dictionary['value']
 
-            if 'dateStyle' in pkpass_field_dictionary:
-                value = Date.from_iso_string(value)
+            if 'dateStyle' in pkpass_field_dictionary \
+                    or 'timeStyle' in pkpass_field_dictionary:
+                date = Date.from_iso_string(value)
+                date_style = pkpass_field_dictionary.get(
+                    'dateStyle', 'PKDateStyleShort')
+                time_style = pkpass_field_dictionary.get(
+                    'timeStyle', 'PKDateStyleShort')
+                value = date.formatted_string(date_style, time_style)
 
             elif 'currencyCode' in pkpass_field_dictionary:
                 value = Currency.format(value, pkpass_field_dictionary['currencyCode'])

--- a/src/model/digital_pass.py
+++ b/src/model/digital_pass.py
@@ -253,8 +253,44 @@ class Date:
     def __lt__(self, other):
         return self.compare(other) < 0
 
+    # Mapping of Apple PKPass date/time style constants to GLib format strings
+    _date_formats = {
+        'PKDateStyleNone':   None,
+        'PKDateStyleShort':  '%x',
+        'PKDateStyleMedium': '%x',
+        'PKDateStyleLong':   '%B %-e, %Y',
+        'PKDateStyleFull':   '%A, %B %-e, %Y',
+    }
+
+    _time_formats = {
+        'PKDateStyleNone':   None,
+        'PKDateStyleShort':  '%R',
+        'PKDateStyleMedium': '%T',
+        'PKDateStyleLong':   '%T %Z',
+        'PKDateStyleFull':   '%T %Z',
+    }
+
     def __str__(self):
         return self.__date.to_local().format('%c')
+
+    def formatted_string(self, date_style='PKDateStyleShort',
+                         time_style='PKDateStyleShort'):
+        """
+        Format the date according to Apple PKPass dateStyle/timeStyle values.
+        """
+        local_date = self.__date.to_local()
+
+        date_fmt = Date._date_formats.get(date_style)
+        time_fmt = Date._time_formats.get(time_style)
+
+        if date_fmt and time_fmt:
+            return local_date.format(date_fmt + ' ' + time_fmt)
+        elif date_fmt:
+            return local_date.format(date_fmt)
+        elif time_fmt:
+            return local_date.format(time_fmt)
+        else:
+            return ''
 
     def as_relative_pretty_string(self):
 


### PR DESCRIPTION
```
Previously, date fields were always displayed using the full locale datetime format (%c), ignoring the dateStyle and timeStyle keys from the PKPass field dictionary. This caused boarding passes (and other pass types) to show excessively long datetime strings like 'Thu 30 Oct 2025 12:42:00 CET' where only the time '12:42' was intended.

Add Date.formatted_string() method that maps Apple's PKDateStyle constants (None, Short, Medium, Long, Full) to appropriate GLib format strings for both date and time components independently.

Update StandardField to read both dateStyle and timeStyle from the field dictionary and produce a properly formatted string instead of storing a raw Date object.

Assisted-by: Claude:claude-opus-4-6
```