### PR TITLE
Add the keyword wallet to desktop file

### DIFF
--- a/data/me.sanchezrodriguez.passes.desktop.in
+++ b/data/me.sanchezrodriguez.passes.desktop.in
@@ -6,7 +6,7 @@ Icon=me.sanchezrodriguez.passes
 Terminal=false
 Type=Application
 Categories=GTK;Utility;
-Keywords=digital pass;espass;pkpass;
+Keywords=digital pass;espass;pkpass;wallet;
 StartupNotify=true
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
Apps that store and display passes are often called wallets, like the ones made by Google and Apple. Therefore I found myself searching for wallet on my system which did not yield any results. Adding "wallet" to the list of keywords would change this.