### PR TITLE
fix adaptiveness issues

### DIFF
--- a/src/view/barcode_dialog.blp
+++ b/src/view/barcode_dialog.blp
@@ -38,6 +38,7 @@ template $BarcodeDialog : Adw.Dialog
             margin-start: 6;
             margin-end: 6;
             margin-bottom: 6;
+            wrap: true;
             styles ["heading"]
         }
     };

--- a/src/view/pass_list/pass_row.blp
+++ b/src/view/pass_list/pass_row.blp
@@ -32,6 +32,7 @@ template $PassRow : Gtk.ListBoxRow
             Gtk.Label subtitle
             {
                 styles ["subtitle"]
+                ellipsize: end;
                 hexpand: true;
                 xalign: 0;
             }

--- a/src/view/window.blp
+++ b/src/view/window.blp
@@ -177,7 +177,17 @@ template $PassesWindow : Adw.ApplicationWindow
                                         }
                                     }
 
-                                    content: $PassWidget pass_widget{};
+                                    content: Gtk.ScrolledWindow
+                                    {
+                                        hscrollbar-policy: never;
+                                        child: $PassWidget pass_widget
+                                        {
+                                            margin-start: 12;
+                                            margin-end: 12;
+                                            margin-top: 12;
+                                            margin-bottom: 12;
+                                        };
+                                    };
                                 }
                             };
 


### PR DESCRIPTION
There are a few widgets that can be larger than the containing widgets them:
 * the pass widget being larger than the height-request of the window,
 * the pass's subtitle being of arbitrary length, and
 * the barcode's alt text being of arbitrary length.

These are simple fixes for these three issues.